### PR TITLE
fix/remove broken links in episode 8

### DIFF
--- a/_episodes/08-motivation.md
+++ b/_episodes/08-motivation.md
@@ -65,7 +65,7 @@ don't belong in this course.
 > If people need to run shell commands on the files they've edited,
 > a substantial fraction won't be able to navigate to the right directory without help.
 > If this seems like a small problem to you,
-> please revisit the discussion of [expert blind spot]({{ page.root }}/08-memory/).
+> please revisit the discussion of [expert blind spot]({{ page.root }}/04-expertise.md#expert-blind-spots).
 {: .callout}
 
 Many of the foundational concepts of computer science,
@@ -169,7 +169,7 @@ to make sure they're doing at least a few of these things.
 > ## Not Just Learners
 >
 > What's missing from this list is strategies to motivate the *instructor*.
-> As we said in [the introduction]({{ page.root }}/02-introduction/),
+> As we said in the introduction,
 > learners respond to an instructor's enthusiasm,
 > and instructors need to care about a topic in order to keep teaching it,
 > particularly when they are volunteers.
@@ -219,8 +219,7 @@ to alienate a classroom and cause learners to tune out.
 *   Pretend to know more than you do.  People will actually trust you
     more if you are frank about the limitations of your knowledge, and
     will be more likely to ask questions and seek help.
-*   Use the J word ("just").
-    As [discussed earlier]({{ page.root }}/08-memory/),
+*   Use the J word ("just");
     this signals to the learner that
     the instructor thinks their problem is trivial
     and by extension that they therefore must be stupid


### PR DESCRIPTION
Fixed the link to expert blind spot mentioned in #63, the other two links (The J word, and introduction) did not seem to have relevant/substantive places to link back to in the current lesson version. 