### PR TITLE
Remove "a" and reverse "can" and "we"

### DIFF
--- a/_episodes/08-motivation.md
+++ b/_episodes/08-motivation.md
@@ -119,7 +119,7 @@ learners have a concrete starting point for debugging.
 > it's useful to check lessons against these points
 > to make sure they're doing at least a few of these things.
 >
-> In groups of to or three, pick a three of these points and describe in one sentence in the Etherpad how can we apply these strategies in our workshops.
+> In groups of to or three, pick three of these points and describe in one sentence in the Etherpad how we can apply these strategies in our workshops.
 >
 > * Strategies to Establish Value
 >     1. Connect the material to students' interests.


### PR DESCRIPTION
The "a" is unnecessary in this sentence, and the "can we" should be "we can".

