### PR TITLE
Update 04-expertise.md

### DIFF
--- a/_episodes/04-expertise.md
+++ b/_episodes/04-expertise.md
@@ -1,95 +1,112 @@
 ---
-title: "How Learning Works: Instruction and Memory"
-teaching: 30
-exercises: 15
+title: "How Learning Works: Expertise and Instruction"
+teaching: 20
+exercises: 30
 questions:
-- "How do experts store knowledge differently from novices?"
-- "How can experts uncover their assumptions and blind spots?"  
+- "What type of instructor is best for novices?"
+- "How are we (as instructors) different from our learners and how does this impact our teaching?"  
 objectives:
-- "Explain how key aspects of expert behavior are results of cognitive differences between experts and competent practitioners."
+- "Identify situations where you have an expert blind spot."
+- "Demonstrate strategies for compensating for your expert blind spot."
+- "Demonstrate strategies for avoiding demotivating language."
 keypoints:
-- "Experts' mental models are much more densely connected than those of non-experts."
+- "Experts face challenges when teaching novices due to expert blind spot."
 - "Expert blind spot: knowing something so well that it seems easy when it's not."
-- "Long-term memory is large but slow, while short-term is fast but (very) small."
-- "Most adults can store 7±2 items in short-term memory for a few seconds before loss."
-- "Teaching consists of loading short-term memory and reinforcing it long enough for items to be transferred to long-term memory."
-- "This reinforcement often takes the form of formative assessment."
-- "One way concept maps can help in lesson planning is by defining appropriate points in a lesson for formative assessment."
+- "With practice, we can learn to overcome our expert blind spot."
 ---
 
 We now discuss what distinguishes expertise
 from earlier stages of learning, how being an expert can make it 
 more difficult to teach novices, and some tools to help instructors 
-identify their own expert blind spots.  
+identify overcome these difficulties.  
 
-## Expertise
+## What Makes an Expert?  
 
-An [earlier topic]({{ page.root }}/01-practice.md) described a key 
+An [earlier topic]({{ page.root }}/02-practice.md) described a key 
 difference between novices and competent practitioners. Competent practitioners 
 have mental models that work well enough for most situations. 
-What makes experts different from either?
+How are experts different from both of these groups?
 
-> ## What Is An Expert?
+> ## What Is An Expert?  
 >
 > 1. Name someone that you think is an expert (doesn't matter what they're 
-> an expert in).  As an expert, what makes them special or different than 
+> an expert in).  As an expert, what makes them special or different from 
 > other people?  
 > 2. What is something that you're an expert in?  How does your experience 
 > when you're acting as an expert differ from when you're not an expert?  
+> 
+> This discussion should take about 5 minutes.
 {: .challenge}
 
-What makes the difference?  The answer is not that experts know more facts:
+The answer is not that experts know more facts:
 competent practitioners can memorize a lot of information
 without any noticeable improvement to their performance.  The answer is 
-rather that experts have more connections between pieces of knowledge; 
+rather that experts have more connections among pieces of knowledge; 
 more "short-cuts", if you will.  
 
-One way to illustrate this is the model 
-of storing knowledge as a graph
+One way to illustrate this is to model 
+storing knowledge as a graph
 in which facts are nodes and relationships are arcs.
 (This is emphatically *not* how our brains work,
 but it's a useful metaphor.)
 The key difference between experts and competent practitioners
-is that experts have many more connections,
-i.e., their mental models are much more densely connected. Therefore 
+is that experts have many more connections among concepts. 
+Their mental models are much more densely connected. Therefore 
 experts can jump directly from a problem to its solution
-because there is a direct link between the two in their mind:
-where a competent practitioner would have to reason "A therefore B therefore C therefore D therefore E",
+because there is a direct link between the two in their mind.
+Where a competent practitioner would have to reason 
+"A therefore B therefore C therefore D therefore E",
 the expert can go from A to E in a single step ("A therefore E").
 
 > ## Connections and Mental Models
 > 
 > The graph model of knowledge explains why
 > helping learners make connections is as important as introducing them to facts.
-> The more people you know in a group,
-> the more likely you are to remain part of that group.
-> Similarly,
-> the more connections a fact has to other facts,
+> The more connections a fact has to other facts,
 > the more likely the fact is to be remembered.  This builds on our earlier idea
-> of mental models - a mental model is a way to facilitate making connections between
-> separate facts.
+> of mental models - a mental model is (in part) a set of connections or relationships
+> among facts or concepts.
 {: .callout}
 
-> ## Other Consequences of Expertise
+## Limitations of Expertise  
+
+Because your learners' mental models will be less densly connected than your own, 
+a conclusion that seems obvious to you will not seem that way to your learners. 
+Another feature of expertise that has important consequences for teaching is the
+ability of experts to make use of *fluid representations*. Two ways of thinking about a problem
+will seem interchangable to an expert, but will not seem that way to a novice. For example, 
+someone with experience using the bash shell will be able to change back and forth between absolute and
+relative paths with no difficulty and in fact may not even notice they are doing so. A novice learner, 
+however, would be confused by this unexplained use of two different ways of representing a concept. 
+
+> ## Fluid Representations  
 > 
-> Experts 
-> - Densely-connected knowledge graphs also explains *fluid representations*, e.g.,
-> expert mathematicians' ability to switch effortlessly between algebraic and geometric views of a problem.
-> - Experts are better at diagnosis than competent practitioners:
-> more linkages between facts makes it easier to reason backward from symptoms to causes.
-> (And this in turn is why asking programmers to debug during job interviews
-> gives a more accurate impression of their ability than asking them to program.)
-{: .callout}
+> In the Etherpad, give at least one example of a fluid representation that you use in your 
+> own work. If you can, also give an example of a fluid representation that might occur in a 
+> Carpentry lesson. 
+> 
+> Building awareness of how you can represent the same concept in multiple different ways
+> will help you avoid doing so without explanation while teaching. 
+> 
+> This discussion should take about 5 minutes.  
+{: .challenge}
 
-While these connections are great for the expert when they're doing 
-their work, they can sometimes hamper their communication and teaching 
-with novices (and even competent practitioners!).  
-When an expert tries to explain her reasoning to a novice,
-she often can't because she didn't go through the intermediate steps a novice would.
+Experts are also better at diagnosing errors than novices or competent practitioners. If faced with an
+error message while teaching, an expert will often figure out the cause of the error and devlop a solution
+before a novice has even finished reading the error message. Because of this, it is very important
+while teaching to be explicit about the process you are using to diagnose and correct errors, even if they
+seem trivial to you, as they often will.
 
-## Expert Blind Spots
+> ## Diagnosis  
+> 
+> What is an error message that you encounter frequently in your work? (These are often syntax errors.) 
+> Take a few minutes to plan out how you would explain that error message to your learners. Write the 
+> error and your explaination in the Etherpad.
+> 
+> This discussion should take about 5 minutes.  
+{: .challenge}
 
-In fact, experts are frequently so familiar with their subject
+Experts are frequently so familiar with their subject
 that they can no longer imagine what it's like to *not* see the world that way. 
 This is called *expert blind spot* and can lead to what's known as the *expertise-reversal effect*.
 Experts are often less good at teaching a subject to novices than people with less expertise
@@ -97,7 +114,7 @@ who still remember what it's like to have to learn the things.
 This effect can be overcome with training,
 but it's part of the reason world-famous researchers are often poor lecturers.
 
-> ## Blind Spots
+> ## Blind Spots  
 >
 > 1. Is there anything you're learning how to do right now?  Can you identify 
 > something that you still need to think about, but your teacher can do without 
@@ -111,15 +128,54 @@ reason why we welcome instructors who still identify as "novices"!  Someone
 who is still in the process of learning can be a more effective instructor 
 because they are speaking from their own recent experience.  
 
-However, that's not to say that experts can't be good teachers.  Experts can 
+In these ways and others, the high connectivity of an expert's mental model poses challenges while teaching 
+novices. However, that's not to say that experts can't be good teachers.  Experts can 
 be effective as long as they take the time to identify and correct 
-for their own expert blind spots.  In the rest of this section we'll be discussing 
-some of the ways that this can be done.  
+for their own expert blind spots. You can use some of the exercises we've done while 
+preparing to teach to help you overcome these
+challenges. 
 
-## You Are Not Your Learners
+## Dismissive Language  
 
-One way to overcome your own blind spots is by understanding the goals 
-and motivations of your learners.  We will discuss this later in the afternoon, 
+Experts often betray their blind spot by using the word "just" in explanations,
+as in, "Oh, it's easy, you just fire up a new virtual machine
+and then you just install these four patches to Ubuntu
+and then you just re-write your entire program in a pure functional style---no problem."
+This gives learners the very clear signal
+that the instructor thinks their problem is trivial
+and that they therefore must be stupid.  
+
+With practice, we can change the way we speak to avoid this type of demotivating language and replace
+it with more positive and motivating word choices.
+
+> ## Changing Your Language  
+>
+> What other words or phrases can have the effect of demotivating learners? What alternatives can we use to
+> express this meaning in a positive and motivational way?  
+>
+> In the Etherpad, make a list of demotivating words/phrases and alternatives.  
+>
+> This discussion should take about 5 minutes.  
+>
+>> ## Solution  
+>> Courtney Seiter lists [10 words and phrases][motivation-words] that can change a conversation: if, could, yes, together, thank you,
+>> choose to, and, because, willing, and the person's name. These are motivating words and phrases that can shift mindsets.
+>> Jason Fried lists several dirty [four-letter words:][four-letter-words] need, must, can’t, easy, just, only, and fast, as well as
+>> examples of how they are used to demotivate. Statements like
+>> *	"We really need it."
+>> *	"If we don’t we can’t ..."
+>> *	"Wouldn’t it be easy if we just did it like that?"
+>> *	"Can you try it real fast?"
+>> can be perceived as dismissive or demeaning or worse.
+>>
+> {: .solution}
+{: .challenge}
+
+## You Are Not Your Learners  
+
+One way to overcome these limitations is by understanding the goals 
+and motivations of your learners.  We will discuss motivation in more depth 
+in a [later lesson]({{ page.root }}/19-motivation/) 
 but for now, consider some of these ideas about the typical audience for 
 Carpentry workshops.  
 
@@ -150,11 +206,11 @@ For these reasons,
 we have adopted a "teach most immediately useful first" approach
 described in [this episode]({{ page.root }}/19-motivation/).
 
-> ## Software Carpentry Is Not Computer Science
+> ## Software/Data Carpentry Is Not Computer Science  
 >
 > Many of the foundational concepts of computer science,
 > such as computability,
-> inhabit the lower-right corner of the grid described above.
+> are diffult to learn and not immediately useful.
 > This does *not* mean that they aren't important,
 > or aren't worth learning,
 > but if our aim is to convince people that they can learn this stuff,
@@ -162,31 +218,13 @@ described in [this episode]({{ page.root }}/19-motivation/).
 > they are less compelling than things like automating repetitive tasks.
 {: .callout}
 
-## More? (To add)
+## The Important of Practice (Again)  
 
-- Continue to emphasize the importance of formative assessment (to help counter blind spot)
-- Add mental model questions cut from previous episode?
-*Which of these questions assesses flaws in a student's mental model of a domain? You don't need to provide answers for these questions.*		
-1. I'm not sure what a mental model is.		
-2. "In Python, what is the expected output for the following statement: 1 + '2'"		
- 	(a) '12'		
- 	(b) TypeError		
- 	(c) '3'		
- 	(d) 3		
- 3. "Rate your experience with the R programming language."		
- 	(a) never used it		
- 	(b) beginner		
- 	(c) intermediate		
- 	(d) expert		
- 4. "What does the Unix command 'cut' do?"		
- 	(a) Extracts sections from each line of input.		
- 	(b) Sorts fields of a line		
- 	(c) Searches the input file for lines containing a match to a pattern		
- 	(d) Removes a given input from a line		
+All of the above points illustrate the importance of using formative assessments frequently. The right 
+formative assessment at the right time will give you valuable information about your learners' goals and
+motivations, making it easier for you to target your lesson materials to their needs. This strategy also helps
+you as an instructor overcome your expert blind spot. It doesn't matter how easy you think a task is, if your
+learners aren't getting it, it's probably more complicated than you thought.
 
-[abela-presentation]: http://extremepresentation.typepad.com/blog/2006/09/choosing_a_good.html
-[amazon-glass]: http://www.amazon.com/Facts-Fallacies-Software-Engineering-Robert/dp/0321117425/
-[macnamara-practice]: http://pss.sagepub.com/content/25/8/1608
-[memory-test]: http://cat.xula.edu/thinker/memory/working/serial
-[wikipedia-7]: https://en.wikipedia.org/wiki/The_Magical_Number_Seven,_Plus_or_Minus_Two
-[wikipedia-serial-position]: https://en.wikipedia.org/wiki/Serial_position_effect
+
+

--- a/_episodes/04-expertise.md
+++ b/_episodes/04-expertise.md
@@ -18,12 +18,14 @@ keypoints:
 We now discuss what distinguishes expertise
 from earlier stages of learning, how being an expert can make it 
 more difficult to teach novices, and some tools to help instructors 
-identify overcome these difficulties.  
+identify and overcome these difficulties.  
 
 ## What Makes an Expert?  
 
 An [earlier topic]({{ page.root }}/02-practice.md) described a key 
-difference between novices and competent practitioners. Competent practitioners 
+difference between novices and competent practitioners. Novices lack a mental model, or have only
+a very incomplete model with limited utility.
+Competent practitioners 
 have mental models that work well enough for most situations. 
 How are experts different from both of these groups?
 
@@ -70,7 +72,7 @@ the expert can go from A to E in a single step ("A therefore E").
 
 ## Limitations of Expertise  
 
-Because your learners' mental models will be less densly connected than your own, 
+Because your learners' mental models will likely be less densely connected than your own, 
 a conclusion that seems obvious to you will not seem that way to your learners. 
 Another feature of expertise that has important consequences for teaching is the
 ability of experts to make use of *fluid representations*. Two ways of thinking about a problem
@@ -108,8 +110,8 @@ seem trivial to you, as they often will.
 
 Experts are frequently so familiar with their subject
 that they can no longer imagine what it's like to *not* see the world that way. 
-This is called *expert blind spot* and can lead to what's known as the *expertise-reversal effect*.
-Experts are often less good at teaching a subject to novices than people with less expertise
+This is called *expert blind spot* and can lead to what's known as the *expertise-reversal effect* - experts are often 
+less good at teaching a subject to novices than people with less expertise
 who still remember what it's like to have to learn the things.
 This effect can be overcome with training,
 but it's part of the reason world-famous researchers are often poor lecturers.
@@ -158,9 +160,11 @@ it with more positive and motivating word choices.
 > This discussion should take about 5 minutes.  
 >
 >> ## Solution  
->> Courtney Seiter lists [10 words and phrases][motivation-words] that can change a conversation: if, could, yes, together, thank you,
->> choose to, and, because, willing, and the person's name. These are motivating words and phrases that can shift mindsets.
->> Jason Fried lists several dirty [four-letter words:][four-letter-words] need, must, can’t, easy, just, only, and fast, as well as
+>> Courtney Seiter lists [10 words and phrases][motivation-words] that can change a conversation: *if*, *could*, *yes*,
+>> *together*, *thank you*,
+>> *choose to*, *and*, *because*, *willing*, and the person's name. These are motivating words and phrases that can shift mindsets.
+>> Jason Fried lists several dirty [four-letter words:][four-letter-words] *need*, *must*, *can’t*, *easy*,
+>> *just*, *only*, and *fast*, as well as
 >> examples of how they are used to demotivate. Statements like
 >> *	"We really need it."
 >> *	"If we don’t we can’t ..."
@@ -170,6 +174,11 @@ it with more positive and motivating word choices.
 >>
 > {: .solution}
 {: .challenge}
+
+Another language choice that can have very positive effects on learner mindset is to ask "What questions do people have?" rather than 
+"Does anyone have any questions?" Asking "Does anyone have any questions?" can create the impression that you hope people don't have
+questions, so that you can continue on with the lesson. By asking what questions people have, you are setting up an expectation that 
+people will, indeed, have questions, and that that is normal and expected. 
 
 ## You Are Not Your Learners  
 
@@ -210,7 +219,7 @@ described in [this episode]({{ page.root }}/19-motivation/).
 >
 > Many of the foundational concepts of computer science,
 > such as computability,
-> are diffult to learn and not immediately useful.
+> are difficult to learn and not immediately useful.
 > This does *not* mean that they aren't important,
 > or aren't worth learning,
 > but if our aim is to convince people that they can learn this stuff,

--- a/_episodes/08-motivation.md
+++ b/_episodes/08-motivation.md
@@ -193,8 +193,6 @@ learners have a concrete starting point for debugging.
 
 ## Demotivation
 
-> If someone feels it's too slow, they'll be a bit bored. If they feel it's too fast, they'll never come back to programming. - Kunal Marwaha, SWC instructor
-
 One of our biggest challenges as instructors when teaching a workshop is to not demotivate participants through our words or actions.
 
 A few common demotivators are *indifference* and *unfairness*.
@@ -241,43 +239,6 @@ to alienate a classroom and cause learners to tune out.
 > Encourage helpers to support confused students as far as possible within
 > the flow of the workshop.
 {: .callout}
-
-## Dismissive Language
-
-Experts often betray their blind spot by using the word "just" in explanations,
-as in, "Oh, it's easy, you just fire up a new virtual machine
-and then you just install these four patches to Ubuntu
-and then you just re-write your entire program in a pure functional style---no problem."
-This gives learners the very clear signal
-that the instructor thinks their problem is trivial
-and that they therefore must be stupid.  
-
-With practice, we can change the way we speak to avoid this type of demotivating language and replace
-it with more positive and motivating word choices.
-
-> ## Changing Your Language
->
-> What other words or phrases can have the effect of demotivating learners? What alternatives can we use to
-> express this meaning in a positive and motivational way?  
->
-> In the Etherpad, make a list of demotivating words/phrases and alternatives.  
->
-> This discussion should take about five minutes.  
->
->> ## Solution  
->> Courtney Seiter lists [10 words and phrases][motivation-words] that can change a conversation: if, could, yes, together, thank you,
->> choose to, and, because, willing, and the person's name. These are motivating words and phrases that can shift mindsets.
->> Jason Fried lists several dirty [four-letter words:][four-letter-words] need, must, can’t, easy, just, only, and fast, as well as
->> examples of how they are used to demotivate. Statements like
->> *	"We really need it."
->> *	"If we don’t we can’t ..."
->> *	"Wouldn’t it be easy if we just did it like that?"
->> *	"Can you try it real fast?"
->> can be perceived as dismissive or demeaning or worse.
->>
-> {: .solution}
-{: .challenge}
-
 
 > ## The Importance of Having Rules
 >


### PR DESCRIPTION
This PR makes several changes to episode 04-expertise.md, including:

1) Updating objectives, key points and questions to stick to a small number of each and fit the new episode contents.

2) Changing the episode title to focus on expertise (there is no discussion of memory in this episode anymore).

3) Adding explicit examples of how the limitations of expertise affect teaching in our workshop setting. 

4) Move content about dismissive language from motivation section because it ties in well with discussion of expert blind spot. 

5) Add exercises for understanding limitations of expertise and developing strategies to overcome them while teaching. 

6) Reiterate importance of formative assessment and explicitly say how it can help overcome limitations of expertise.