### PR TITLE
Update 12-homework.md

### DIFF
--- a/_episodes/12-homework.md
+++ b/_episodes/12-homework.md
@@ -12,7 +12,13 @@ keypoints:
 - ""
 ---
 
-As homework overnight, please:
+Today we have focused on understanding some core findings of pedagogical research about how the learning process
+works and the importance of creating a positive classroom environment. We also introduced the idea of lesson study
+and gave some opportunities to practice teaching. Tomorrow we will continue our discussions of
+how we build teaching skill and will have more chances for practice and feedback. We will also
+look in some depth at how the Carpentries operate to prepare you for the logistics of teaching a workshop.
+
+To prepare for tomorrow, please:
 
 1.  Read about the two types of Carpentry workshops: [self-organized][dc-self] and 
     [centrally-organized][dc-central] and the checklists

--- a/_episodes/12-homework.md
+++ b/_episodes/12-homework.md
@@ -6,7 +6,7 @@ questions:
 - "What have we learned today?"
 - "What needs to be done to prepare for tomorrow?"
 objectives:
-- "Understand overnight homework."
+- "Describe overnight homework."
 - "Produce a paragraph, drawing, or diagram that summarizes what was taught today."  
 keypoints:
 - ""
@@ -14,17 +14,15 @@ keypoints:
 
 As homework overnight, please:
 
-1.  Read our [operations guide]({{ site.swc_site }}/workshops/operations/) and the checklists it links to.
-    These recommendations and how-to guides summarize what we have learned (often the hard way)
-    about organizing and running workshops.
+1.  Read about the two types of Carpentry workshops: [self-organized][dc-self] and 
+    [centrally-organized][dc-central] and the checklists
+    these pages link to. These summarize commonly asked questions about organizing and running workshops.
     When you arrive tomorrow, we will ask you to add one question about our operations to a list.
     We will then do our best to answer all of those questions during the day.
 
-2.  Read "[Software Carpentry: Lessons Learned]({{ page.root }}/files/papers/wilson-lessons-learned-2016.pdf)",
-    which summarizes what we have learned over 18 years of teaching basic computing skills to researchers.
-
-3.  Prepare for the live coding exercises.
-    Pick an episode from an existing Software or Data Carpentry lesson and read through it carefully.
+2.  Prepare for the live coding exercises.
+    If you haven't already, pick an episode from an existing Software or Data Carpentry lesson and 
+    read through it carefully.
     Tomorrow, you will use this to practice live coding for 5 minutes in groups of three.
     Your group members will comment on the delivery and content.
     The episodes we recommend were listed in the welcome message
@@ -43,7 +41,7 @@ As homework overnight, please:
 
 > ## Feedback
 >
-> The trainer will ask for feedback on the day in some form.  
+> The Trainer(s) will ask for feedback on the day in some form.  
 >
 > This exercise should take 5 minutes.  
 {: .challenge}
@@ -53,7 +51,7 @@ As homework overnight, please:
 > Before we wrap up for the day, take 5 minutes to think over
 > everything we covered today.  On a piece of paper, write
 > down something that captures what you want to remember about
-> the day.  The trainers won't look at this - it's just for you.  
+> the day.  The Trainers won't look at this - it's just for you.  
 >
 > If you don't know where to start, consider
 > the following list for a starting point:
@@ -67,3 +65,6 @@ As homework overnight, please:
 >
 > This exercise should take about 10 minutes.
 {: .challenge}
+
+[dc-self]: {{ site.dc_site }}/self-organized-workshops/
+[dc-central]: {{ site.dc_site }}/workshops-host/


### PR DESCRIPTION
This PR updates the episode 12-homework.md including:

1) Changing links from SWC operations guide to DC checklists.

2) Removing the SWC Lessons Learned paper from overnight homework. It's just too much 
to ask them to read this, along with looking at our operations and preparing to teach.