### PR TITLE
update 23-checkout.md

### DIFF
--- a/_episodes/23-checkout.md
+++ b/_episodes/23-checkout.md
@@ -1,65 +1,78 @@
 ---
 title: "Afternoon Wrap-Up"
-teaching: 30
-exercises: 15
+teaching: 10
+exercises: 35
 questions:
-- "What have we learned?"
-- "What do we do next?"
+- "What do I need to do to finish certifying as a Carpentry instructor?"
 objectives:
-- "Understand final steps required to qualify as an instructor."
-- "Evaluate the utility of the instructor training workshop."
-- "Recognize that training was valuable, useful, and appreciated."
+- "Describe the final steps required to qualify as an instructor."
+- "Schedule your instructor discussion session."
+- "Provide final feedback to your instructors."
 keypoints:
-- "Final steps to qualify are to make a contribution, take part in a discussion, and do a teaching demo."
+- "To certify, you must contribute to a lesson, take part in a discussion, and do a teaching demo."
 ---
 
 
 ## Application form
 
-Be sure that you have filled out the Carpentries [instructor application form](https://amy.software-carpentry.org/forms/request_training/).  We can not track your progress and make you an official instructor without it.   
-
+Make sure that you have filled out the Carpentries 
+[instructor application form](https://amy.software-carpentry.org/forms/request_training/). 
+We can not track your progress and make you an official instructor without it. If you have already
+filled out this form, you do not need to submit another application.
 
 ## Instructor Checkout
 
-The final three steps in qualifying as an instructor are to:
+As you read in your homework last night, the final three steps in qualifying as an instructor are to:
 
-1.  Make a contribution to a lesson's content, exercises, or instructor's guide by doing **one** of the following:
-    1.  Submit a change request to fix an existing issue.
+1.  Make a contribution to a lesson's content, exercises, or instructor notes by doing **one** of the following:
+    1.  Submit a change (i.e. pull request to fix an existing issue.
     2.  Proof-read a lesson and add a new issue describing something to be improved.
     3.  Provide substantive feedback on an existing issue or pull request.
 2.  Take part in a [discussion session][discussion] with experienced instructors.
 3.  Do a 5-minute [live coding demo][demo].
 
-[This page]({{ page.root }}/checkout/) explains the procedure in detail;
-please review it with your instructor before you leave.
+[This page]({{ page.root }}/checkout/) explains the procedure in detail. 
+There's also a [helpful checklist](http://www.datacarpentry.org/checkout/) 
+if you'd prefer a brief summary.
 
-## Provide Feedback
-
-We frequently ask for summary feedback at the end of each day.
-The instructors ask the learners to alternately give one positive and one negative point about the day,
-without repeating anything that has already been said.
-This requirement forces people to say things they otherwise might not:
-once all the "safe" feedback has been given,
-participants will start saying what they really think.
-
-[Minute cards]({{ page.root }}/06-summarize/) are anonymous;
-the alternating up-and-down feedback is not.
-Each mode has its strengths and weaknesses, and by providing both, we hope to get the best of both worlds.
-
-## One Up, One Down
-
-Provide one up, one down feedback on the entire two-day course.
-
-Just as in our regular workshops,
-we collect post-instructor-training-workshop feedback.
-Your participation will help us evaluate the efficacy of this training
-and improve the content and delivery of the lesson materials.
-
-> ## Feedback
+> ## Questions and Answers
 > 
-> The trainer will ask for feedback on the day in some form.  
+> What questions do you have about the checkout process after reading the checkout guide 
+> as homework last night?
 > 
-> This exercise should take 5 minutes.  
+> This discussion should take about 10 minutes.
+{: .exercise}
+
+> ## Schedule a Discussion or Demo
+> 
+> Visit the [discussion Etherpad][discussion] to sign up for a session. 
+> If the session you would like to attend is full, contact the discussion
+> host and co-host to ask if you can attend. 
+>
+> If you'd prefer to do your teaching demonstration before your discussion, 
+> visit the [demo Etherpad][demo] and sign up there. 
+>
+> This exercise should take 5 minutes.
+{: .challenge}
+
+> ## One Up, One Down
+> 
+> Provide one up, one down feedback on the entire two-day course.
+> 
+> Just as in our regular workshops,
+> we collect post-instructor-training-workshop feedback.
+> Your participation will help us evaluate the efficacy of this training
+> and improve the content and delivery of the lesson materials.
+> 
+> This exercise should take 5 minutes.
+{: .challenge}
+
+> ## Minute Cards
+> 
+> In addition to giving one up, one down feedback. Please also fill out your sticky
+> notes to give your instructors anonymous feedback. 
+> 
+> This exercise should take 5 minutes.
 {: .challenge}
 
 > ## Post Workshop Surveys
@@ -70,12 +83,11 @@ and improve the content and delivery of the lesson materials.
 > This exercise should take 10 minutes.  
 {: .challenge}
 
-
 ## Thank You
 
 Thank you for taking part in this instructor-training workshop.
 We hope it was a valuable and enjoyable experience,
-and we look forward to your continued involvement in the Software and Data Carpentry community.
+and we look forward to having you as Carpentry instructors!
 
 [discussion]: http://pad.software-carpentry.org/instructor-discussion
 [demo]: http://pad.software-carpentry.org/teaching-demos


### PR DESCRIPTION
This PR updates the Checkout episode, including:

1) Updating questions, objectives and keypoints.
2) Updating timing estimates. 
3) Adding question and answer session about checkout.
4) Adding exercise for participants to sign up for discussion and/or demo sessions. I've done this at my last several workshops and have found it to remove some of the inertia in getting people to complete checkout. One down-side to this is if the sessions are already full (which they often are).
5) Turning feedback into exercises (formatting).