### PR TITLE
Update 22-carpentries.md

### DIFF
--- a/_episodes/22-carpentries.md
+++ b/_episodes/22-carpentries.md
@@ -68,11 +68,11 @@ computational literacy among researchers and other professionals worldwide.
 
 - **[Maintainers](https://software-carpentry.org/join/subcom/maintainers/)** oversee curricular changes and maintain the high-quality of Carpentry lessons.  
 
-- **Lesson Infrastructure** Subcommittee members make decissions about and implement changes to lesson templates to ensure a good user experience across our lessons.
+- **Lesson Infrastructure** Subcommittee members make decisions about and implement changes to lesson templates to ensure a good user experience across our lessons.
 
 - **Policy** Subcommittee members moderate discussion lists and arbitrate reported Code of Conduct violations.
 
-- The **Steering Committees** makes strategic decisions about the future of the organization and its operations.
+- The **Steering Committees** make strategic decisions about the future of the organization and its operations.
 
 - **Local Champions** advocate for the Carpentries within their home institution and region, growing a local network of Carpentry instructors and supporting workshop learners. 
 

--- a/_episodes/22-carpentries.md
+++ b/_episodes/22-carpentries.md
@@ -1,57 +1,30 @@
 ---
 title: "The Carpentries: How We Operate"
-teaching: 60
-exercises: 15
+teaching: 30
+exercises: 35
 questions:
 - "How are Software and Data Carpentry organized and run?"
 objectives:
-- "Summarize the history and structure of the Software and Data Carpentry organizations."
-- "Describe at least three similarities and differences between Software and Data Carpentry workshops."
+- "Get connected with the Carpentry community."
+- "Describe where you can go to get information on running a workshop."
 keypoints:
-- "Software Carpentry was founded in 1998 to teach scientists how to program better."
-- "Data Carpentry was founded in 2014 to teach researchers how to handle data."
-- "Their materials are all openly licensed, but their names and logos are trademarked."
-- "They share teaching methods and a common instructor pool."
-- "The workshop operations guide summarizes what they have learned about organizing and delivering training."
+- "Carpentry materials are all openly licensed, but their names and logos are trademarked."
+- "Carpentry workshops must cover core concepts, have at least one certified instructor, use our pre- and post-workshop surveys and report attendance information."
+
 ---
+
 In becoming an instructor for Software or Data Carpentry,
 you are also becoming part of a community of like-minded volunteers.
-This section provides some background on both organizations,
-and on the final steps toward certification.
-
-> ## Preparation and Discussion
->
-> This discussion assumes that trainees have read the [operations guide]({{ site.swc_site }}/workshops/operations/)
-> (which is [assigned as overnight homework]({{ page.root }}/12-summarize/)).
-{: .callout}
+This section provides some background on both organizations and information 
+about how you can get involved.
 
 ## History
 
-[Software Carpentry]({{ site.swc_site }} ) was co-founded in 1998 by Brent Gorda and
-Greg Wilson, who identified a need for best practices training in
-research computing.  After several iterations, the current model of
-two-day workshops with a standard curriculum emerged in 2010-11.
-After intermediate support from various organizations, it became an
-independent organization called the [Software Carpentry
-Foundation]({{ site.swc_site }}/scf/) (SCF) in 2015.  The SCF is now responsible for all
-aspects of Software Carpentry's operations. For more on Software Carpentry's history,
-and on what we've learned along the way,
-see [this page]({{ site.swc_site }}/scf/history/) on its website
-or the paper "[Software Carpentry: Lessons Learned](http://f1000research.com/articles/3-62/v2)".
-
-[Data Carpentry]({{ site.dc_site }}) was founded in 2013 
-under the leadership of Tracy Teal. Data Carpentry trains researchers 
-in the core data skills for efficient, shareable, and reproducible research 
-practices. Data Carpentry run accessible, inclusive training workshops; 
-teach openly available, high-quality, domain-tailored lessons; and foster 
-an active, inclusive, diverse instructor community that promotes and models 
-reproducible research as a community norm. For more information, 
-visit [the Data Carpentry website](http://www.datacarpentry.org/about/) or 
-read this paper "[Data Carpentry: Workshops to Increase Data Literacy for Researchers](http://ijdc.net/index.php/ijdc/article/view/10.1.135).
-
-Software and Data Carpentry are both fiscally sponsored projects of [NumFOCUS](https://www.numfocus.org/),
-a 501(c)(3) non-profit foundation based in the United States. The two organizations share many aspects of their
-operations, long-term goals, and community structure:
+[Software Carpentry]({{ site.swc_site }} ) was founded in 1998 and 
+[Data Carpentry]({{ site.dc_site }}) was founded in 2013. You can learn more about the history
+and goals of each organization by reading 
+"[Software Carpentry: Lessons Learned](http://f1000research.com/articles/3-62/v2)" and
+"[Data Carpentry: Workshops to Increase Data Literacy for Researchers](http://ijdc.net/index.php/ijdc/article/view/10.1.135).
 
 *   Both focus on computational skills.
 *   Both run two-day workshops taught by volunteer instructors.
@@ -65,45 +38,96 @@ but rather those who have a lot of data and don't know what to do with it.
 Data Carpentry workshops:
 
 *   are aimed at pure novices,
-*   domain-specific, and
+*   are domain-specific, and
 *   present a full curriculum centered around a single data set.
 
-Software Carpentry workshops focus on best practices for software development and use.
-Its workshops are:
+Software Carpentry workshops are:
 
 *   intended for people who need to program more effectively to solve their
-    computational challenges,
+computational challenges,
 *   not domain-specific, and
 *   modular---each Software Carpentry lesson is standalone.
 
 ![Software Carpentry and Data Carpentry Comparison](../fig/SWCvsDC.png)
 
-## Workshop Operations
+In February 2017, Software and Data Carpentry began to discuss merging the two organizations. As of 
+August 2017, this merger is underway and planned to take effect in early 2018. Software and Data 
+Carpentry will join under an umbrella organization ("The Carpentries"), with a shared governance, 
+community structure, and policies. Each organization will maintain their own curricular materials.
 
-We have recorded what we've learned about writing workshops
-in an [operations guide]({{ site.swc_site }}/workshops/operations/)
-and a set of checklists (linked from that page)
-that describes what everyone involved in a workshop is expected to do and why.
-Questions, corrections, and additions are *very* welcome.
+## The Carpentry Community
 
-> ## How We Do Things
+The Carpentry Community has several parts, which function together to spread data skills and 
+computational literacy among researchers and other professionals worldwide. 
+
+- **Instructors** teach workshops and form the cornerstone of the Carpentry community. Many also serve in some of the other roles listed below.   
+
+- **Trainers** are Carpentry instructors who have received additional training in pedagogy. They traing new instructors, develop the instructor training curriculum, and lead teaching demonstrations.
+
+- **[Mentors](https://software-carpentry.org/join/subcom/mentoring/)** help new instructors integrate into the community by leading discussion sessions. Some also lead small mentoring groups to help new instructors prepare for their first few workshops. 
+
+- **[Maintainers](https://software-carpentry.org/join/subcom/maintainers/)** oversee curricular changes and maintain the high-quality of Carpentry lessons.  
+
+- **Lesson Infrastructure** Subcommittee members make decissions about and implement changes to lesson templates to ensure a good user experience across our lessons.
+
+- **Policy** Subcommittee members moderate discussion lists and arbitrate reported Code of Conduct violations.
+
+- The **Steering Committees** makes strategic decisions about the future of the organization and its operations.
+
+- **Local Champions** advocate for the Carpentries within their home institution and region, growing a local network of Carpentry instructors and supporting workshop learners. 
+
+- **Other Roles:** There are many other ways to get involved with the Carpentries, whether by participating in lesson development events or contributing to our blogs. 
+
+There are many ways to get connected with the Carpentry community:
+
+*   Our websites are:
+    *   [Software Carpentry]({{ site.swc_site }})
+        *   [Blog]({{ site.swc_site }}/blog/)
+        *   [Get Involved]({{ site.swc_site }}/join/)
+    *   [Data Carpentry]({{ site.dc_site }})
+        *   [Blog]({{ site.dc_site }}/blog/)
+        *   [Get Involved]({{ site.dc_site }}/involved/)
+*   Our lessons are hosted on GitHub;
+contributions to them and discussion of changes happens via GitHub pull requests and issues,
+and the lessons are published using GitHub Pages.
+More details are given below.
+    *   [Data Carpentry on GitHub]({{ site.dc_github }})
+    *   [Software Carpentry on GitHub]({{ site.swc_github }})
+*   Software and Data Carpentry share public discussion lists
+that host everything from lively discussion on teaching practices
+to job postings and general announcements.
+    * [General Discussion list](http://lists.software-carpentry.org/listinfo/discuss)  
+    * [Other lists](http://lists.software-carpentry.org/)  
+*   We publish a [joint newsletter](http://www.datacarpentry.org/newsletter/),
+*   Host monthly community calls and weekly instructor discussion sessions,
+    * Check out our [community calendar](https://software-carpentry.org/join/)
+*   You can also find us on Twitter:
+    *   [Software Carpentry on Twitter](https://twitter.com/swcarpentry)
+    *   [Data Carpentry on Twitter](https://twitter.com/datacarpentry)
+*   [Slack](https://swc-slack-invite.herokuapp.com/)
+*   and [Facebook](https://www.facebook.com/carpentries/)
+
+> ## Get Connected
 >
-> Go to the [operations guide]({{ site.swc_site }}/workshops/operations/)
-> and read the instructions for a regular instructor
-> and for a workshop host.
-> What situations might come up that these *don't* answer?
+> Take a couple of minutes to sign up for the Carpentry discussion channels you want to stay involved with.  
 {: .challenge}
 
-If you would like to host a Software Carpentry workshop at 
-your institution, [visit this website for more information](https://software-carpentry.org/workshops/request/). 
+## How a Workshop Works
 
-If you would like to host a Data Carpentry workshop at your 
-institution, [visit this website for more information](http://www.datacarpentry.org/workshops-host/).
+There are two types of Carpentry workshops: self-organized and centrally-organized. 
+For a centrally-organized workshop, Carpentry staff takes care of organization and adminstration
+such as finding instructors and handling workshop registration. For a self-organized workshop,
+all of these details are handled by the instructors or organization hosting the event.
 
-Policies related to instructor training and workshops for both Software Carpentry and 
-Data Carpentry can be found [here](https://github.com/carpentries/policies). Two documents 
-of use are the **[code of conduct](https://github.com/carpentries/policies/blob/master/code-of-conduct.md)**, 
-and the **[instructor no show policy](https://github.com/carpentries/policies/blob/master/instructor-no-show-policy.md)**
+If you would like to host a Software Carpentry workshop at
+your institution, [visit this website for more information](https://software-carpentry.org/workshops/request/).
+
+If you would like to host a Data Carpentry workshop at your
+institution, [visit this website for more information on centrally-organized workshops](http://www.datacarpentry.org/workshops-host/) and this website for more information about [self-organized workshops](http://www.datacarpentry.org/self-organized-workshops/).
+
+Policies related to instructor training and workshops for both Software Carpentry and
+Data Carpentry can be found [here](https://github.com/carpentries/policies). Please
+be sure to read through the [instructor no-show policy](https://github.com/carpentries/policies/blob/master/instructor-no-show-policy.md) before planning your first workshop.
 
 ### Materials
 
@@ -111,21 +135,6 @@ All of Software Carpentry and Data Carpentry's lessons materials are freely avai
 under a permissive [open license]({{ page.root }}/license/).
 You may use them whenever and however you want,
 provided you cite the original source.
-
-> ## What's Core?
->
-> Our learners have such a wide spread of prior knowledge
-> that no one fixed lesson could possibly fit everyone's needs.
-> We have therefore provided more material than most people will get through most of the time
-> in order to be (reasonably) sure that we have enough for more advanced classes.
-> In particular:
->
-> 1. Callouts (like this one) contain material that isn't essential to the lesson,
->    and which most instructors will skip.
-> 2. Many lessons have more exercises than an instructor would use;
->    your job is to decide which exercises will be most useful for your audience.
->    Remember, practice is how we learn, so give lots of opportunities for practice.
-{: .callout}
 
 ### Using the Names
 
@@ -138,6 +147,18 @@ You may only call a workshop a Software Carpentry or Data Carpentry workshop if:
 *   at least one instructor is certified,
 *   you run our standardized pre- and post-workshop assessments and provide us with the results, and
 *   you send us summary information about attendees (at a minimum, the number of people who attended).
+
+### What's Core?
+
+A Software Carpentry workshop must include lessons on version control (e.g. git), the shell,
+and a programming language (e.g. R or Python). 
+
+A Data Carpentry workshop must include a Data Carpentry lesson on data organization and three
+other modules in the same domain from the Data Carpentry curriculum. 
+
+Within these guidelines, there is flexibility in which episodes of the lesson you cover,
+which exercises you use, and whether you include optional materials (e.g. callouts) and 
+optional episodes.  
 
 ### Who Can Teach What
 
@@ -158,75 +179,33 @@ the [workshop coordinator](mailto:admin@software-carpentry.org),
 who adds it to our records.
 The workshop will show up on our websites shortly thereafter.
 
-> ## Practice With SWC Infrastructure
+> ## Practice With SWC or DC Infrastructure
 >
-> Go to the [workshop template repository]({{ site.workshop_repo }}) and follow the directions
-> to create a workshop website using your local location and today's date.
+> Go to the [SWC workshop template repository]({{ site.workshop_repo }})
+> or the [DC workshop template repository]({{ site.dc_github }}/workshop-template)
+> and follow the directions to create a workshop website using your local location and today's date.
+> Put the link for your workshop website into the Etherpad.
+> 
+> This exercise should take about 10 minutes.
 {: .challenge}
 
-We also have [a small installer for Windows](https://github.com/swcarpentry/windows-installer/releases/download/v0.3/SWCarpentryInstaller.exe)
-to help people set up their environment,
-which is maintained in [this GitHub repository](https://github.com/swcarpentry/windows-installer).
-This installer runs *after* the installer that puts Git and Bash on Windows,
-and does the following:
-
-*   Installs GNU Make and makes it accessible from msysGit
-*   Installs nano and makes it accessible from msysGit
-*   Installs SQLite and makes it accessible from msysGit
-*   Creates a ~/nano.rc with links to syntax highlighting configurations
-*   Provides standard nosetests behavior for msysGit
-*   Adds R's bin directory to the path (if we can find it)
-
-Please see the setup instructions in the workshop template for more details.
-
-## The Carpentry Community
-
-There are many ways to get connected with the Software and Data Carpentry communities:
-
-*   Our websites are:
-    *   [Software Carpentry]({{ site.swc_site }})
-        *   [Blog]({{ site.swc_site }}/blog/)
-        *   [Get Involved]({{ site.swc_site }}/join/)
-    *   [Data Carpentry]({{ site.dc_site }})
-        *   [Blog]({{ site.dc_site }}/blog/)
-        *   [Get Involved]({{ site.dc_site }}/involved/)
-*   Our lessons are hosted on GitHub;
-    contributions to them and discussion of changes happens via GitHub pull requests and issues,
-    and the lessons are published using GitHub Pages.
-    More details are given below.
-    *   [Data Carpentry on GitHub]({{ site.dc_github }})
-    *   [Software Carpentry on GitHub]({{ site.swc_github }})
-*   Software and Data Carpentry share public discussion lists
-    that host everything from lively discussion on teaching practices
-    to job postings and general announcements.
-    * [General Discussion list](http://lists.software-carpentry.org/listinfo/discuss)  
-    * [Other lists](http://lists.software-carpentry.org/)  
-*   We publish a [joint monthly newsletter](http://www.datacarpentry.org/newsletter/),
-*   Host monthly community calls and weekly instructor discussion sessions,
-    * Check out our [community calendar](https://software-carpentry.org/join/)
-*   You can also find us on Twitter:
-    *   [Software Carpentry on Twitter](https://twitter.com/swcarpentry)
-    *   [Data Carpentry on Twitter](https://twitter.com/datacarpentry)
-*   [Slack](https://swc-slack-invite.herokuapp.com/)
-*   and [Facebook](https://www.facebook.com/carpentries/)
-
-> ## Get Connected
->
-> Take a couple of minutes to sign up for the Carpentry discussion channels you want to stay involved with.  
+> ## Question and Answer
+> 
+> What questions do you have about running and teaching at a workshop? Talk with a partner and
+> enter your questions into the Etherpad.
+> 
+> Leave about 10 minutes for this discussion.
 {: .challenge}
 
-### A Culture of Contribution
 
-The administration, policies, practices and content of
-Software Carpentry and Data Carpentry rest on the shoulders of the
-communities that support them.  In the same way that we hope to promote a
+## A Culture of Contribution
+
+In the same way that we hope to promote a
 culture of openness, sharing,
 and reproducibility in science and research through training researchers with
 the tools they need, the
 Carpentry organizations themselves aim to be open, collaborative, and
-based on best practices.  Just
-as we encourage researchers to use packages and modules in their code, to
-create re-usable pieces, we want to draw together the collective expertise of
+based on best practices.  We want to draw together the collective expertise of
 our teaching community to create collaborative lessons, share other materials,
 and improve the lessons via "bug fixes" as we go along.
 
@@ -238,8 +217,7 @@ are hosted on GitHub:
 *   [Data Carpentry on GitHub]({{ site.dc_github }})
 *   [Software Carpentry on GitHub]({{ site.swc_github }})
 
-and are developed collaboratively---in 2015 alone, almost 200 people
-made contributions to various lessons.  Each lesson is in a separate
+and are developed collaboratively.  Each lesson is in a separate
 repository, and consists of narrative lesson material and an
 associated directory containing the data or scripts needed in the
 lesson.  This source material is also then served as a website, using
@@ -251,20 +229,26 @@ as issues, discussed by the community, and addressed via a pull
 request, which serves as a "request" to make changes, and can also
 be discussed before changes are merged.  
 
-### Lesson Incubation
+> ## Check Out the Discussion
+> 
+> As an instructor, your voice is important! We want you to be actively involved
+> in disucssions about the lesson materials (and other aspects of the Carpentry community).
+> Go to the GitHub page for the lesson you worked with over the past two days and click on the 
+> "Issues" tab. Read through some of the discussions and, if you have anything to add, please add it
+> to the conversation! If you do make a significant contribution to the discussion, send a link to
+> the issue to [checkout@carpentries.org](mailto: checkout@carpentries.org). Congratulations! You've 
+> just completed one of the three remaining steps in becoming a Carpentry instructor.
+> 
+> Leave about 5-10 minutes for this exercise.
+{: .challenge}
 
-Maybe this instructor training has inspired you to go home and write your
-own fantastic lesson!  If you'd like to model it after the Software and
-Data Carpentry lesson format, you can go to [this repository]({{ site.example_repo }}) for
-a template and instructions.  
-
-Writing a new lesson can be a lot of work.  While some people have written
-new lessons on their own, other people have asked people in the community to
-help them.  If you think there are other people who would be interested in
-your lesson idea, you can email the Software and Data Carpentry discussion
-lists to find out if anyone is interested.  If so, one person will typically
-take the lead and be the lesson's director and maintainer until it's ready to
-be taught.  
+> ## Lesson Incubation
+> 
+> Maybe this instructor training has inspired you to go home and write your
+> own fantastic lesson!  If you'd like to model it after the Software and
+> Data Carpentry lesson format, you can go to [this repository]({{ site.example_repo }}) for
+> a template and instructions.  
+{: .callout}
 
 > ## Many Ways to Contribute
 >
@@ -276,49 +260,8 @@ be taught.
 > please let us know.
 {: .callout}
 
-### Beyond Lessons
-
-While contribution is frequently seen in terms of contributing
-to specific lessons in either organization, there
-are many, many ways to contribute and participate in the Software and Data
-Carpentry communities.
-
-* Contributing to discussion and development of lessons and policies, via
-discussions on Github issues/pull requests or email discuss lists
-* Writing blog posts and bringing important ideas/news to the community
-* Developing tools
-* Hosting and organizing workshops
-* Contributing to lessons via raising issues or submitting pull requests
-* Leadership and administrative positions, including being a lesson maintainer,
- or serving on a committee.
-
-Here are some examples of ways that people have contributed to the community:
-
-  * [This email thread](http://lists.software-carpentry.org/pipermail/discuss/2015-October/003396.html)
-is a good example of many instructors chiming in on a topic, resulting in a
-[blog post](http://software-carpentry.org/blog/2015/10/pulling-along-those-behind.html),
-summarizing the discussion.
-  * [Discussion on a significant pull request](https://github.com/swcarpentry/r-novice-gapminder/pull/89).
-
-So being part of a friendly, open discussion, is of equal or greater importance
+Being part of a friendly, open discussion, is of equal or greater importance
 to the community than submitting the perfect lesson change.  The
 [checkout process]({{ page.root }}/checkout/) to become a fully-fledged instructor will be
 one way to start connecting to the community and find which area will allow you
 to contribute best.
-
-### Governance
-
-Software Carpentry is a democracy:
-its seven-member [Steering Committee]({{ site.swc_site }}/scf/ ) is elected annually
-by and from its membership,
-which includes every instructor who has taught in the two years leading up to the election.
-The Steering Committee has final say on all strategic and financial decisions;
-if you would like Software Carpentry to take a new direction,
-or would like to do more than teach or develop lessons,
-you are very welcome to put your name forward as a candidate.
-
-Data Carpentry is governed by a volunteer Steering Committee and run by its Staff. 
-The Steering Committee provides strategic vision and oversight of Data Carpentry.
-Staff and Steering Committee members are committed to ensuring that activities are 
-welcoming and inclusive, and the organization and all its events and communications 
-adhere to a Code of Conduct.


### PR DESCRIPTION
This pull request updates 22-carpentries with several changes, including:

1) Updating time estimates.
2) Updating keypoints, objectives and questions to match current content.
3) Removing reference to operations guide as overnight homework.
4) Shortening history and linking to papers for more information.
5) Adding paragraph about merger and umbrella "Carpentries" organization.
6) Summarizing the structure of the Carpentry community. 
7) Moving section about communication channels to rest of discussion of community.
8) Adding distinction between self- and centrally-organized workshops.
9) Making "what's core" a part of the lesson (rather than a callout) and refocusing it to talk about what the requirements are for content in order to call something a SWC or DC workshop.
10) Shortening the section on lesson incubation and removing section on governance (but referencing the steering committee earlier in the episode).
11) Adding exercise for trainees to look at existing issues and add to the discussion. This gets them through step one of checkout if they do it during the workshop and at the very least gives them a good idea of what the conversations around lesson development look like.